### PR TITLE
fix: disable Cross-Exchange Spread strategy (Coinbase not ready)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -29,7 +29,7 @@ data:
   
   # Market Logic Strategies (from QTZD adaptation)
   STRATEGY_ENABLED_BTC_DOMINANCE: "true"
-  STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD: "true"
+  STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD: "false"
   STRATEGY_ENABLED_ONCHAIN_METRICS: "false"
   
   # Order Book Skew Strategy Parameters

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,6 +120,21 @@ spec:
             configMapKeyRef:
               name: petrosa-realtime-strategies-config
               key: STRATEGY_ENABLED_TICKER_VELOCITY
+        - name: STRATEGY_ENABLED_BTC_DOMINANCE
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-realtime-strategies-config
+              key: STRATEGY_ENABLED_BTC_DOMINANCE
+        - name: STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-realtime-strategies-config
+              key: STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD
+        - name: STRATEGY_ENABLED_ONCHAIN_METRICS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-realtime-strategies-config
+              key: STRATEGY_ENABLED_ONCHAIN_METRICS
         - name: TRADING_SYMBOLS
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## Problem
The Cross-Exchange Spread strategy is enabled and trying to fetch Coinbase prices every 6 seconds, generating error logs:
```
Error fetching coinbase prices (every 6 seconds)
```

## Root Cause
- Strategy was enabled but Coinbase integration is not ready yet
- Missing environment variables in deployment meant strategy always used hardcoded default (true)
- No Coinbase API keys configured

## Changes
1. **Disabled Cross-Exchange Spread Strategy**
   - `STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD: "false"` in configmap.yaml

2. **Added Missing Environment Variables to Deployment**
   - `STRATEGY_ENABLED_BTC_DOMINANCE`
   - `STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD`  
   - `STRATEGY_ENABLED_ONCHAIN_METRICS`
   
   This ensures deployment actually reads these settings from ConfigMap instead of using hardcoded defaults.

## Impact
- ✅ Stops Coinbase API call attempts
- ✅ Eliminates error logs (every 6 seconds)
- ✅ Other 5 strategies continue running normally
- ✅ Strategy code remains intact for future use
- ✅ ConfigMap already patched in cluster for immediate fix

## Future
When ready for Coinbase integration:
- Add Coinbase API credentials to secrets
- Set `STRATEGY_ENABLED_CROSS_EXCHANGE_SPREAD: "true"`
- Deploy and test cross-exchange arbitrage

Refs: Coinbase premature activation issue