### PR TITLE
fix: Add OTLP log export to realtime-strategies

### DIFF
--- a/otel_init.py
+++ b/otel_init.py
@@ -6,16 +6,21 @@ This module sets up OpenTelemetry instrumentation for observability,
 including metrics, traces, and logs collection.
 """
 
+import logging
 import os
+import socket
 import sys
 from typing import Optional
-import socket
 
 # Add project root to path
 project_root = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, project_root)
 
 import constants  # noqa: E402
+
+# Global logger provider for attaching handlers
+_global_logger_provider = None
+_otlp_logging_handler = None
 
 
 def find_available_port(start_port: int, max_attempts: int = 10) -> int:
@@ -41,15 +46,21 @@ def setup_telemetry(service_name: Optional[str] = None) -> None:
         return
 
     try:
-        from opentelemetry import trace
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
         from opentelemetry.instrumentation.logging import LoggingInstrumentor
         from opentelemetry.instrumentation.requests import RequestsInstrumentor
         from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
-        from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
         # Set up resource
         resource = Resource.create({
@@ -81,8 +92,45 @@ def setup_telemetry(service_name: Optional[str] = None) -> None:
             )
             trace_provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
 
-        # Set up instrumentations
-        LoggingInstrumentor().instrument()
+        # Set up metrics
+        if otlp_endpoint:
+            metric_headers_env = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+            metric_headers = None
+            if metric_headers_env:
+                metric_headers_list = [
+                    tuple(h.split("=", 1)) for h in metric_headers_env.split(",") if "=" in h
+                ]
+                metric_headers = dict(metric_headers_list)
+            
+            metric_reader = PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=otlp_endpoint, headers=metric_headers),
+                export_interval_millis=int(os.getenv("OTEL_METRIC_EXPORT_INTERVAL", "60000"))
+            )
+            meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+            metrics.set_meter_provider(meter_provider)
+            print(f"✅ OpenTelemetry metrics enabled")
+
+        # Set up logging export via OTLP
+        if otlp_endpoint:
+            global _global_logger_provider
+            LoggingInstrumentor().instrument(set_logging_format=False)
+            
+            log_headers_env = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+            log_headers = None
+            if log_headers_env:
+                log_headers_list = [
+                    tuple(h.split("=", 1)) for h in log_headers_env.split(",") if "=" in h
+                ]
+                log_headers = dict(log_headers_list)
+            
+            log_exporter = OTLPLogExporter(endpoint=otlp_endpoint, headers=log_headers)
+            logger_provider = LoggerProvider(resource=resource)
+            logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+            _global_logger_provider = logger_provider
+            print(f"✅ OpenTelemetry logging export configured")
+            print("   Note: Call attach_logging_handler() for health server in lifespan")
+
+        # Set up HTTP instrumentations
         RequestsInstrumentor().instrument()
         URLLib3Instrumentor().instrument()
         AioHttpClientInstrumentor().instrument()
@@ -129,6 +177,98 @@ def setup_metrics() -> None:
         print("⚠️  Prometheus client not available")
     except Exception as e:
         print(f"❌ Failed to start Prometheus server: {e}")
+
+
+def attach_logging_handler():
+    """
+    Attach OTLP logging handler to root logger and uvicorn loggers.
+    
+    For FastAPI health server - must attach to uvicorn loggers.
+    Call this in the health server's lifespan startup function.
+    """
+    global _global_logger_provider, _otlp_logging_handler
+
+    if _global_logger_provider is None:
+        print("⚠️  Logger provider not configured - logging export not available")
+        return False
+
+    try:
+        # Get loggers
+        root_logger = logging.getLogger()
+        uvicorn_logger = logging.getLogger("uvicorn")
+        uvicorn_access_logger = logging.getLogger("uvicorn.access")
+        uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+        # Check if handler already attached
+        if _otlp_logging_handler is not None:
+            if _otlp_logging_handler in root_logger.handlers:
+                print("✅ OTLP logging handler already attached")
+                return True
+
+        # Create and attach handler
+        handler = LoggingHandler(
+            level=logging.NOTSET,
+            logger_provider=_global_logger_provider,
+        )
+
+        # Attach to all loggers
+        root_logger.addHandler(handler)
+        uvicorn_logger.addHandler(handler)
+        uvicorn_access_logger.addHandler(handler)
+        uvicorn_error_logger.addHandler(handler)
+
+        _otlp_logging_handler = handler
+
+        print("✅ OTLP logging handler attached to root and uvicorn loggers")
+        print(f"   Root logger handlers: {len(root_logger.handlers)}")
+        print(f"   Uvicorn logger handlers: {len(uvicorn_logger.handlers)}")
+
+        return True
+
+    except Exception as e:
+        print(f"⚠️  Failed to attach logging handler: {e}")
+        return False
+
+
+def attach_logging_handler_simple():
+    """
+    Attach OTLP logging handler to root logger only.
+    
+    For the main async service (NATS consumer) - simpler version.
+    Call this in main() after setup_telemetry().
+    """
+    global _global_logger_provider, _otlp_logging_handler
+
+    if _global_logger_provider is None:
+        print("⚠️  Logger provider not configured - logging export not available")
+        return False
+
+    try:
+        root_logger = logging.getLogger()
+
+        # Check if handler already attached
+        if _otlp_logging_handler is not None:
+            if _otlp_logging_handler in root_logger.handlers:
+                print("✅ OTLP logging handler already attached")
+                return True
+
+        # Create and attach handler
+        handler = LoggingHandler(
+            level=logging.NOTSET,
+            logger_provider=_global_logger_provider,
+        )
+
+        root_logger.addHandler(handler)
+        _otlp_logging_handler = handler
+
+        print("✅ OTLP logging handler attached to root logger")
+        print(f"   Total handlers: {len(root_logger.handlers)}")
+
+        return True
+
+    except Exception as e:
+        print(f"⚠️  Failed to attach logging handler: {e}")
+        return False
 
 
 if __name__ == "__main__":

--- a/strategies/main.py
+++ b/strategies/main.py
@@ -28,11 +28,14 @@ from strategies.utils.heartbeat import HeartbeatManager  # noqa: E402
 
 # Initialize OpenTelemetry as early as possible
 try:
-    from otel_init import setup_telemetry, setup_metrics  # noqa: E402
+    import otel_init  # noqa: E402
 
     if not os.getenv("OTEL_NO_AUTO_INIT"):
-        setup_telemetry(service_name=constants.OTEL_SERVICE_NAME)
-        setup_metrics()
+        otel_init.setup_telemetry(service_name=constants.OTEL_SERVICE_NAME)
+        otel_init.setup_metrics()
+        # Attach OTLP logging handler for main async service logs
+        # Health server will attach its own handler via lifespan
+        otel_init.attach_logging_handler_simple()
 except ImportError:
     pass
 


### PR DESCRIPTION
## Summary

Apply lessons learned from tradeengine logging fix (PR #75) to enable complete observability for the realtime-strategies service.

## Changes

### Updated `otel_init.py`
- Added complete OTLP export setup (metrics, traces, logs)
- Added `attach_logging_handler()` for FastAPI/Uvicorn (health server)
- Added `attach_logging_handler_simple()` for async NATS consumer
- Configured log export with BatchLogRecordProcessor

### Updated `strategies/health/server.py`
- Added lifespan function to FastAPI app
- Call `otel_init.attach_logging_handler()` for uvicorn logger attachment
- Proper handler attachment after uvicorn configures logging

### Updated `strategies/main.py`
- Call `otel_init.attach_logging_handler_simple()` for NATS consumer logs

## Architecture-Specific Implementation

This service has **dual architecture**:

1. **FastAPI health server** (Uvicorn)
   - ✅ Attach to **root + uvicorn loggers** via lifespan
   - ✅ Uses `attach_logging_handler()` (full uvicorn support)

2. **Async NATS consumer** (no web server)
   - ✅ Attach to **root logger only** in main()
   - ✅ Uses `attach_logging_handler_simple()`

Both architectures handled properly with appropriate handler functions.

## Expected Outcome

After deployment:
- ✅ Health server logs (health checks, metrics endpoint)
- ✅ NATS consumer logs (message processing, strategy execution)
- ✅ All logs appear in Grafana Cloud Loki
- ✅ Traces and metrics continue working
- ✅ Complete observability achieved

## Verification

Check Grafana Loki for logs:
```logql
{service_name="realtime-strategies"} |= ""
```

Refs: Final service in observability rollout (Service 4/4)