### PR TITLE
feat: add FastAPI instrumentation for distributed tracing

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -120,6 +120,11 @@ spec:
             configMapKeyRef:
               name: petrosa-common-config
               key: OTEL_LOGS_EXPORTER
+        - name: OTEL_EXPORTER_OTLP_HEADERS
+          valueFrom:
+            secretKeyRef:
+              name: petrosa-sensitive-credentials
+              key: OTEL_EXPORTER_OTLP_HEADERS
         - name: HEALTH_CHECK_PORT
           valueFrom:
             configMapKeyRef:

--- a/otel_init.py
+++ b/otel_init.py
@@ -142,6 +142,14 @@ def setup_telemetry(service_name: Optional[str] = None) -> None:
         URLLib3Instrumentor().instrument()
         AioHttpClientInstrumentor().instrument()
         
+        # Try to instrument FastAPI (optional)
+        try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+            # Note: FastAPI instrumentation will be applied when FastAPI app is created
+            print("✅ FastAPI instrumentation available")
+        except ImportError:
+            print("⚠️  OpenTelemetry FastAPI instrumentation not available")
+        
         # Try to instrument asyncio (optional)
         try:
             from opentelemetry.instrumentation.asyncio import AsyncioInstrumentor

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ opentelemetry-instrumentation-requests>=0.41b0
 opentelemetry-instrumentation-urllib3>=0.41b0
 opentelemetry-instrumentation-asyncio>=0.41b0
 opentelemetry-instrumentation-aiohttp-client>=0.41b0
+opentelemetry-instrumentation-fastapi>=0.41b0
 opentelemetry-sdk>=1.20.0
 opentelemetry-semantic-conventions>=0.41b0
 

--- a/strategies/health/server.py
+++ b/strategies/health/server.py
@@ -95,6 +95,14 @@ class HealthServer:
             lifespan=lifespan,
         )
 
+        # Instrument FastAPI for OpenTelemetry tracing
+        try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+            FastAPIInstrumentor.instrument_app(self.app)
+            self.logger.info("✅ FastAPI instrumented for OpenTelemetry tracing")
+        except Exception as e:
+            self.logger.warning(f"⚠️  Failed to instrument FastAPI: {e}")
+
         # Server state
         self.server = None
         self.is_running = False


### PR DESCRIPTION
## Summary
This PR adds FastAPI instrumentation to enable trace generation from the health server endpoints for realtime-strategies service.

## Changes
- Add `opentelemetry-instrumentation-fastapi>=0.41b0` to requirements.txt
- Add FastAPI instrumentation availability check in otel_init.py
- Instrument FastAPI app in health server with `FastAPIInstrumentor.instrument_app()`
- Add `OTEL_EXPORTER_OTLP_HEADERS` environment variable to deployment

## Why This Was Needed
The service was generating logs but not traces because:
- FastAPI auto-instrumentation library was not installed
- FastAPI app was not explicitly instrumented
- Missing OTEL headers prevented proper authentication with Grafana Cloud

## Testing
- Built Docker image successfully with new dependencies
- Verified no linting errors
- Ready for deployment and verification in Kubernetes

## Impact
- **Before**: realtime-strategies had logs but no traces in Grafana Cloud
- **After**: realtime-strategies will generate traces from FastAPI health endpoints

## Related Issue
Fixes missing traces for realtime-strategies service in observability stack.