### PR TITLE
hotfix: Fix MongoDB secret key reference

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -195,7 +195,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: petrosa-sensitive-credentials
-              key: mongodb-uri
+              key: mongodb-url
         - name: MONGODB_DATABASE
           value: "petrosa"
         - name: MONGODB_TIMEOUT_MS


### PR DESCRIPTION
## Issue
Deployment failing with CreateContainerConfigError because mongodb-uri key doesn't exist in secret.

## Fix
- Change secret key reference from mongodb-uri to mongodb-url
- This matches the actual key in the petrosa-sensitive-credentials secret

## Testing
- Verified secret contains mongodb-url key
- Deployment will proceed once PR is merged

## Priority
HOTFIX - Blocking production deployment