### PR TITLE
fix: use gitleaks v1 (free) instead of v2 and fix Trivy SARIF upload

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -91,9 +91,10 @@ jobs:
           fetch-depth: 0  # Full history for secret detection
 
       - name: 🔐 Run Gitleaks (Secret Detection)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # Optional - works without license in v1
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -126,7 +127,7 @@ jobs:
 
       - name: Upload Trivy results
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
## 🔧 Fixes

This PR addresses two critical GitHub Actions workflow issues:

### 1. 🔐 Gitleaks License Error
- **Problem**: Workflow was using `gitleaks/gitleaks-action@v2` which requires a paid license
- **Solution**: Switched to `gitleaks/gitleaks-action@v1` (free version)
- **Impact**: Secret detection continues to work without requiring a license purchase

### 2. 🗂️ Trivy SARIF Upload Error  
- **Problem**: Upload step was failing when the `trivy-results.sarif` file didn't exist (when Trivy scan failed)
- **Solution**: Added file existence check: `if: always() && hashFiles('trivy-results.sarif') != ''`
- **Impact**: Prevents workflow failure when SARIF file is missing

## 📋 Changes
- Updated `.github/workflows/ci-checks.yml`:
  - Changed `gitleaks-action@v2` → `gitleaks-action@v1`
  - Added conditional SARIF upload based on file existence

## ✅ Testing
- Pre-commit hooks passed
- Workflow syntax is valid
- No functional changes to the application code

## 🔗 Related
This fix is being applied across all Petrosa services to ensure consistent CI/CD pipeline behavior.