### PR TITLE
[INFRA] Restore and Standardize Local Test Environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ pydantic>=2.0.0,<3.0.0
 structlog>=23.0.0
 
 # OpenTelemetry (unified via petrosa-otel package)
-# For local development: pip install -e ../petrosa_k8s/petrosa-otel[fastapi,mongodb]
-petrosa-otel[fastapi,mongodb]>=1.0.0
+# For local development: pip install -e ../petrosa_k8s/petrosa-otel[fastapi>=0.110.0
+petrosa-otel[fastapi>=0.110.0
 
 # CLI and utilities
 typer>=0.9.0
@@ -22,7 +22,7 @@ httpx>=0.25.0
 
 # Monitoring and health checks
 prometheus-client>=0.19.0
-fastapi>=0.104.0
+fastapi>=0.110.0
 uvicorn>=0.24.0
 psutil>=5.9.0
 
@@ -30,3 +30,4 @@ psutil>=5.9.0
 motor>=3.3.2
 pymongo>=4.6.0
 pymysql>=1.1.0
+starlette>=0.37.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,18 @@
+import os
+import pytest
+
+# Disable OpenTelemetry auto-initialization during tests
+os.environ['OTEL_NO_AUTO_INIT'] = '1'
+os.environ['OTEL_SDK_DISABLED'] = 'true'
+os.environ['OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED'] = 'false'
+
+def pytest_configure(config):
+    """
+    Setup before any tests are run.
+    """
+    os.environ['OTEL_NO_AUTO_INIT'] = '1'
+    os.environ['OTEL_SDK_DISABLED'] = 'true'
+
 """
 Pytest configuration and fixtures for Petrosa Realtime Strategies tests.
 """


### PR DESCRIPTION
## Problem Statement
Standardizes the local development and test environment across the Petrosa ecosystem.

## Changes
- Upgraded fastapi/starlette to resolve HTTPX incompatibility
- Added OTel shield to conftest.py to disable telemetry during tests
- Installed missing pytest plugins

Addresses PetroSa2/petrosa_k8s#137