### PR TITLE
fix(ci): enforce strict pipeline gate on required checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -189,32 +189,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test, test-quality, security, documentation-standards]
     if: always()
-    permissions:
-      checks: write
-      statuses: write
     steps:
-      - name: Create pipeline status check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const conclusion = '${{ needs.lint.result }}' === 'success' && 
-                              '${{ needs.test.result }}' === 'success' && 
-                              '${{ needs.test-quality.result }}' === 'success' && 
-                              '${{ needs.security.result }}' === 'success' && 
-                              '${{ needs.documentation-standards.result }}' === 'success' 
-                              ? 'success' : 'failure';
-            
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'pipeline',
-              head_sha: context.sha,
-              status: 'completed',
-              conclusion: conclusion,
-              output: {
-                title: conclusion === 'success' ? 'All checks passed' : 'Some checks failed',
-                summary: conclusion === 'success' 
-                  ? 'All CI checks passed successfully.'
-                  : 'One or more CI checks failed. Please review the failed jobs.'
-              }
-            });
+      - name: Validate upstream job results
+        run: |
+          echo "lint=${{ needs.lint.result }}"
+          echo "test=${{ needs.test.result }}"
+          echo "test-quality=${{ needs.test-quality.result }}"
+          echo "security=${{ needs.security.result }}"
+          echo "documentation-standards=${{ needs.documentation-standards.result }}"
+
+          [[ "${{ needs.lint.result }}" == "success" ]]
+          [[ "${{ needs.test.result }}" == "success" ]]
+          [[ "${{ needs.test-quality.result }}" == "success" ]]
+          [[ "${{ needs.security.result }}" == "success" ]]
+          [[ "${{ needs.documentation-standards.result }}" == "success" ]]


### PR DESCRIPTION
## Summary
- replace synthetic pipeline status creation with hard validation of upstream job results
- ensure  job fails when any required dependency job fails

## Why
Recent merges showed  reported success while child checks failed. This change makes  a true gate.

## Validation
- workflow logic now checks 
- branch protection still enforces required checks
