### PR TITLE
fix: correct OTel guard — use SDK attribute instead of sys.argv (#146 AC1)

### DIFF
--- a/strategies/health/server.py
+++ b/strategies/health/server.py
@@ -6,7 +6,6 @@ for Kubernetes liveness and readiness probes, plus configuration API.
 """
 
 import asyncio
-import sys
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -130,15 +129,13 @@ class HealthServer:
             self.app.middleware("http")(config_rate_limit_middleware)
             self.logger.info("✅ Configuration rate limit middleware registered")
 
-        # Instrument FastAPI for OpenTelemetry tracing — skip if already handled by
-        # the opentelemetry-instrument CLI wrapper (k8s deployment command), which
-        # auto-instruments FastAPI before the application starts. Calling
-        # instrument_fastapi() again would trigger "Attempting to instrument while
-        # already instrumented" warnings from the OTel SDK.
-        _is_auto_instrumented = any(
-            "opentelemetry-instrument" in arg for arg in sys.argv
-        )
-        if not _is_auto_instrumented:
+        # Instrument FastAPI for OpenTelemetry tracing — skip if the OTel SDK has
+        # already instrumented this app (e.g., via the opentelemetry-instrument CLI
+        # wrapper in k8s, which replaces fastapi.FastAPI with _InstrumentedFastAPI and
+        # sets _is_instrumented_by_opentelemetry=True on every new app instance).
+        # Calling instrument_fastapi() on an already-instrumented app triggers an
+        # "Attempting to instrument while already instrumented" warning from the OTel SDK.
+        if not getattr(self.app, "_is_instrumented_by_opentelemetry", False):
             try:
                 from petrosa_otel.instrumentors import instrument_fastapi
 

--- a/strategies/health/server.py
+++ b/strategies/health/server.py
@@ -130,11 +130,12 @@ class HealthServer:
             self.logger.info("✅ Configuration rate limit middleware registered")
 
         # Instrument FastAPI for OpenTelemetry tracing — skip if the OTel SDK has
-        # already instrumented this app (e.g., via the opentelemetry-instrument CLI
-        # wrapper in k8s, which replaces fastapi.FastAPI with _InstrumentedFastAPI and
-        # sets _is_instrumented_by_opentelemetry=True on every new app instance).
-        # Calling instrument_fastapi() on an already-instrumented app triggers an
-        # "Attempting to instrument while already instrumented" warning from the OTel SDK.
+        # already instrumented this app, as indicated by
+        # _is_instrumented_by_opentelemetry=True. This may happen through the
+        # opentelemetry-instrument CLI wrapper in k8s or by other SDK-managed
+        # instrumentation paths. Calling instrument_fastapi() on an already
+        # instrumented app triggers an "Attempting to instrument while already
+        # instrumented" warning from the OTel SDK.
         if not getattr(self.app, "_is_instrumented_by_opentelemetry", False):
             try:
                 from petrosa_otel.instrumentors import instrument_fastapi

--- a/tests/test_issue_146_otel_fixes.py
+++ b/tests/test_issue_146_otel_fixes.py
@@ -71,9 +71,10 @@ class TestAutoInstrumentationGuard:
             patch("strategies.health.server.FastAPI") as MockFastAPI,
         ):
             _setup_mock_constants(mock_const)
-            # Simulate plain FastAPI (no auto-instrumentation): attribute absent
+            # Simulate plain FastAPI (no auto-instrumentation): attribute absent.
+            # spec=FastAPI excludes _is_instrumented_by_opentelemetry (not on the real
+            # class), so getattr(app, ..., False) returns the default False — no del needed.
             mock_app = MagicMock(spec=FastAPI)
-            del mock_app._is_instrumented_by_opentelemetry  # ensure attribute absent
             MockFastAPI.return_value = mock_app
             HealthServer(port=8080)
 

--- a/tests/test_issue_146_otel_fixes.py
+++ b/tests/test_issue_146_otel_fixes.py
@@ -1,11 +1,12 @@
 """
 Tests for issue #146 fixes:
-  - AC1: No 'Attempting to instrument' warning when opentelemetry-instrument is in sys.argv
+  - AC1: No 'Attempting to instrument' warning when FastAPI app is already auto-instrumented
   - AC2: attach_logging_handler() not called from lifespan (single call via main.py)
 """
 
 from unittest.mock import MagicMock, patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from strategies.health.server import HealthServer
@@ -34,10 +35,11 @@ def _setup_mock_constants(mock_const) -> None:
 
 
 class TestAutoInstrumentationGuard:
-    """AC1: instrument_fastapi() skipped when CLI wrapper already active."""
+    """AC1: instrument_fastapi() skipped when app is already auto-instrumented by OTel SDK."""
 
-    def test_instrument_fastapi_not_called_when_auto_instrumented(self):
-        """HealthServer.__init__ must skip instrument_fastapi() when opentelemetry-instrument is in sys.argv."""
+    def test_instrument_fastapi_not_called_when_app_already_instrumented(self):
+        """HealthServer.__init__ must skip instrument_fastapi() when the FastAPI app already
+        has _is_instrumented_by_opentelemetry=True (set by opentelemetry-instrument CLI)."""
         mock_instrumentors = MagicMock()
 
         with (
@@ -45,18 +47,20 @@ class TestAutoInstrumentationGuard:
             patch.dict(
                 "sys.modules", {"petrosa_otel.instrumentors": mock_instrumentors}
             ),
-            patch(
-                "sys.argv",
-                ["opentelemetry-instrument", "python", "-m", "strategies.main"],
-            ),
+            patch("strategies.health.server.FastAPI") as MockFastAPI,
         ):
             _setup_mock_constants(mock_const)
+            # Simulate _InstrumentedFastAPI: auto-instrumentation sets the attribute on init
+            mock_app = MagicMock(spec=FastAPI)
+            mock_app._is_instrumented_by_opentelemetry = True
+            MockFastAPI.return_value = mock_app
             HealthServer(port=8080)
 
         mock_instrumentors.instrument_fastapi.assert_not_called()
 
-    def test_instrument_fastapi_called_when_not_auto_instrumented(self):
-        """HealthServer.__init__ must call instrument_fastapi() when opentelemetry-instrument is absent from sys.argv."""
+    def test_instrument_fastapi_called_when_app_not_yet_instrumented(self):
+        """HealthServer.__init__ must call instrument_fastapi() when the FastAPI app has
+        not yet been instrumented (no opentelemetry-instrument CLI in the command)."""
         mock_instrumentors = MagicMock()
 
         with (
@@ -64,37 +68,35 @@ class TestAutoInstrumentationGuard:
             patch.dict(
                 "sys.modules", {"petrosa_otel.instrumentors": mock_instrumentors}
             ),
-            patch("sys.argv", ["python", "-m", "strategies.main"]),
+            patch("strategies.health.server.FastAPI") as MockFastAPI,
         ):
             _setup_mock_constants(mock_const)
+            # Simulate plain FastAPI (no auto-instrumentation): attribute absent
+            mock_app = MagicMock(spec=FastAPI)
+            del mock_app._is_instrumented_by_opentelemetry  # ensure attribute absent
+            MockFastAPI.return_value = mock_app
             HealthServer(port=8080)
 
         mock_instrumentors.instrument_fastapi.assert_called_once()
 
-    def test_guard_detects_cli_wrapper_in_any_argv_position(self):
-        """HealthServer skips instrument_fastapi() regardless of where opentelemetry-instrument appears in argv."""
-        cases = [
-            ["opentelemetry-instrument", "python"],
-            ["/usr/bin/opentelemetry-instrument", "python"],
-            ["python", "opentelemetry-instrument"],
-        ]
+    def test_instrument_fastapi_called_when_attribute_explicitly_false(self):
+        """Guard falls through to manual instrumentation when _is_instrumented_by_opentelemetry=False."""
+        mock_instrumentors = MagicMock()
 
-        for argv in cases:
-            mock_instrumentors = MagicMock()
-            with (
-                patch("strategies.health.server.constants") as mock_const,
-                patch.dict(
-                    "sys.modules", {"petrosa_otel.instrumentors": mock_instrumentors}
-                ),
-                patch("sys.argv", argv),
-            ):
-                _setup_mock_constants(mock_const)
-                HealthServer(port=8080)
+        with (
+            patch("strategies.health.server.constants") as mock_const,
+            patch.dict(
+                "sys.modules", {"petrosa_otel.instrumentors": mock_instrumentors}
+            ),
+            patch("strategies.health.server.FastAPI") as MockFastAPI,
+        ):
+            _setup_mock_constants(mock_const)
+            mock_app = MagicMock(spec=FastAPI)
+            mock_app._is_instrumented_by_opentelemetry = False
+            MockFastAPI.return_value = mock_app
+            HealthServer(port=8080)
 
-            (
-                mock_instrumentors.instrument_fastapi.assert_not_called(),
-                (f"instrument_fastapi was called for argv={argv}"),
-            )
+        mock_instrumentors.instrument_fastapi.assert_called_once()
 
 
 class TestLifespanNoDuplicateLoggingHandler:
@@ -120,7 +122,6 @@ class TestLifespanNoDuplicateLoggingHandler:
                     "petrosa_otel.instrumentors": MagicMock(),
                 },
             ),
-            patch("sys.argv", ["opentelemetry-instrument", "python"]),
         ):
             _setup_mock_constants(mock_const)
             server = HealthServer(port=8080)
@@ -134,7 +135,6 @@ class TestLifespanNoDuplicateLoggingHandler:
         with (
             patch("strategies.health.server.constants") as mock_const,
             patch.dict("sys.modules", {"petrosa_otel.instrumentors": MagicMock()}),
-            patch("sys.argv", ["opentelemetry-instrument", "python"]),
         ):
             _setup_mock_constants(mock_const)
             server = HealthServer(port=8080)


### PR DESCRIPTION
## Summary

Follow-up to #148 (merged). The `sys.argv` guard introduced in that PR does not work in production:

- `opentelemetry-instrument` spawns Python as a subprocess — `sys.argv` in the running process is `['-m', 'strategies.main', 'run']`, never containing `opentelemetry-instrument`.
- The guard always evaluated `False` in k8s, calling `instrument_fastapi()` on every startup → reproducing AC1.
- **AC2 was fixed in #148** (duplicate `attach_logging_handler` removed) — confirmed in k8s logs.
- **AC1 was NOT fixed** — verified by post-rollout `kubectl logs` on `v1.0.5-r138`.

## Root cause

`opentelemetry-instrument` patches `fastapi.FastAPI` → `_InstrumentedFastAPI`. Any new `FastAPI()` instance created after patching gets `_is_instrumented_by_opentelemetry = True` set in `__init__`. The OTel SDK's `instrument_app()` checks this attribute and warns if `True`.

## Fix

Replace `sys.argv` heuristic with `getattr(self.app, "_is_instrumented_by_opentelemetry", False)` — the canonical OTel SDK signal — checked immediately after `self.app = FastAPI(...)` is constructed.

## Test plan

- [x] 5 behavioral tests: mock `FastAPI` app instance with `_is_instrumented_by_opentelemetry=True/False/absent` to test actual `HealthServer.__init__` path
- [x] 606 tests pass, 5 skipped, 3 xfailed — no regressions
- [ ] K8s: deploy and confirm no `"Attempting to instrument FastAPI"` warning in startup logs (AC1)
- [x] K8s: AC2 already confirmed in post-#148 logs — no duplicate logging handler

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)