### PR TITLE
[BUG][CRITICAL] Route realtime-strategies signals through CIO LLM governance (#153)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -20,9 +20,9 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 # NATS Configuration
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
 NATS_CONSUMER_TOPIC = os.getenv("NATS_CONSUMER_TOPIC", "binance.websocket.data")
-# Standardized output topic for signals.trading
+# Publisher topic routes through CIO; tradeengine is never written to directly
 NATS_PUBLISHER_TOPIC = os.getenv(
-    "NATS_TOPIC_SIGNALS", os.getenv("NATS_PUBLISHER_TOPIC", "signals.trading")
+    "NATS_TOPIC_SIGNALS", os.getenv("NATS_PUBLISHER_TOPIC", "cio.intent.trading")
 )
 NATS_TOPIC_INTENTS = os.getenv("NATS_TOPIC_INTENTS", "cio.intent.trading")
 NATS_CONSUMER_NAME = os.getenv("NATS_CONSUMER_NAME", "realtime-strategies-consumer")

--- a/constants.py
+++ b/constants.py
@@ -20,11 +20,11 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 # NATS Configuration
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
 NATS_CONSUMER_TOPIC = os.getenv("NATS_CONSUMER_TOPIC", "binance.websocket.data")
-# Publisher topic routes through CIO; tradeengine is never written to directly
-NATS_PUBLISHER_TOPIC = os.getenv(
-    "NATS_TOPIC_SIGNALS", os.getenv("NATS_PUBLISHER_TOPIC", "cio.intent.trading")
-)
+# All signals/orders route through CIO; NATS_TOPIC_INTENTS is the single source of truth.
+# NATS_PUBLISHER_TOPIC is retained for health-endpoint display only — it mirrors NATS_TOPIC_INTENTS
+# so that the two never drift.
 NATS_TOPIC_INTENTS = os.getenv("NATS_TOPIC_INTENTS", "cio.intent.trading")
+NATS_PUBLISHER_TOPIC = NATS_TOPIC_INTENTS
 NATS_CONSUMER_NAME = os.getenv("NATS_CONSUMER_NAME", "realtime-strategies-consumer")
 NATS_CONSUMER_GROUP = os.getenv("NATS_CONSUMER_GROUP", "realtime-strategies-group")
 

--- a/strategies/core/consumer.py
+++ b/strategies/core/consumer.py
@@ -819,17 +819,16 @@ class NATSConsumer:
 
     async def _publish_market_logic_signals(self, signals) -> None:
         """
-        Publish market logic signals to the trade engine.
+        Publish market logic signals to the trade engine via CIO.
 
-        Converts signals to order format and publishes via NATS.
+        Routes through cio.intent.trading so the LLM governance layer
+        (regime analysis, strategy assessment, action classification) is
+        consulted before any order reaches the tradeengine.
         """
         try:
             for signal in signals:
-                # Convert signal to order format
-                order_data = self._signal_to_order(signal)
-
-                # Publish to trade engine
-                await self.publisher.publish_order(order_data)
+                # Publish signal via CIO intent topic (same path as microstructure)
+                await self.publisher.publish_signal(signal)
 
                 self.logger.info(
                     "Market logic signal published",

--- a/strategies/core/publisher.py
+++ b/strategies/core/publisher.py
@@ -73,8 +73,10 @@ class TradeOrderPublisher:
     def _signal_subject_for_order(self, order: TradeOrder) -> str:
         """
         Build NATS subject routing orders through the CIO intent topic.
-        Uses NATS_TOPIC_INTENTS so all orders pass through LLM governance
-        before reaching the tradeengine (matches TA-bot / publish_signal contract).
+
+        Always uses constants.NATS_TOPIC_INTENTS (not self.topic) so all
+        orders pass through LLM governance before reaching the tradeengine.
+        self.topic is retained for display/health reporting only.
         NATS subjects cannot contain spaces — normalize strategy_name accordingly.
         """
         base = constants.NATS_TOPIC_INTENTS.rstrip(".*>")

--- a/strategies/core/publisher.py
+++ b/strategies/core/publisher.py
@@ -72,11 +72,12 @@ class TradeOrderPublisher:
 
     def _signal_subject_for_order(self, order: TradeOrder) -> str:
         """
-        Tradeengine subscribes to ``signals.trading.>``; a bare ``signals.trading``
-        publish is not delivered. Match TA-bot / CIO contract: ``{base}.{strategy}``.
+        Build NATS subject routing orders through the CIO intent topic.
+        Uses NATS_TOPIC_INTENTS so all orders pass through LLM governance
+        before reaching the tradeengine (matches TA-bot / publish_signal contract).
         NATS subjects cannot contain spaces — normalize strategy_name accordingly.
         """
-        base = self.topic.rstrip(".*>")
+        base = constants.NATS_TOPIC_INTENTS.rstrip(".*>")
         strategy_token = order.strategy_name.replace(" ", "_").replace(".", "_")
         return f"{base}.{strategy_token}"
 
@@ -419,7 +420,7 @@ class TradeOrderPublisher:
                 strategy_id=signal_dict.get("strategy_id"),
                 publishing_time_ms=publishing_time,
                 signal_count=self.signal_count,
-                topic=self.topic,
+                topic=subject,
             )
 
         except Exception as e:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -557,6 +557,37 @@ async def test_consumer_process_market_logic_strategies_exception(consumer):
 
 
 @pytest.mark.asyncio
+async def test_publish_market_logic_signals_uses_publish_signal(
+    consumer, mock_publisher
+):
+    """Verify _publish_market_logic_signals routes via publish_signal (CIO path), not publish_order."""
+    from datetime import datetime
+
+    from strategies.models.signals import (
+        Signal,
+        SignalAction,
+        SignalConfidence,
+        SignalType,
+    )
+
+    signal = Signal(
+        symbol="BTCUSDT",
+        signal_type=SignalType.BUY,
+        signal_action=SignalAction.OPEN_LONG,
+        confidence=SignalConfidence.HIGH,
+        confidence_score=0.85,
+        price=50000.0,
+        timestamp=datetime.utcnow(),
+        strategy_name="btc_dominance",
+    )
+
+    await consumer._publish_market_logic_signals([signal])
+
+    mock_publisher.publish_signal.assert_called_once_with(signal)
+    mock_publisher.publish_order.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_consumer_signal_to_order_conversion(consumer):
     """Test _signal_to_order method - covers lines 758-760, 779, 781."""
     from opentelemetry import trace


### PR DESCRIPTION
Closes #153

## Summary

- `_publish_market_logic_signals` was calling `publish_order()` which routes to `signals.trading.*` — bypassing the CIO orchestrator entirely
- Changed it to call `publish_signal()` (same path as microstructure strategies at line 711), routing to `cio.intent.trading.*`
- All market logic signals (btc_dominance, cross_exchange_spread, onchain_metrics) now go through LLM governance: regime analysis → strategy health → action classification
- Hardened `constants.py` default topic and `_signal_subject_for_order` for consistency

## Changes Made

- `strategies/core/consumer.py`: `_publish_market_logic_signals` now calls `publish_signal(signal)` directly
- `constants.py`: `NATS_PUBLISHER_TOPIC` default changed from `signals.trading` → `cio.intent.trading`
- `strategies/core/publisher.py`: `_signal_subject_for_order` uses `NATS_TOPIC_INTENTS` (consistent with `publish_signal`); log `topic` field now shows actual subject

## Testing

- [x] All 606 tests pass
- [x] 88% test coverage (threshold: 40%)
- [x] Ruff lint clean
- [x] Pre-commit pipeline passed

## Acceptance Criteria Met

- [x] `petrosa-realtime-strategies` publisher routes signals to `cio.intent.trading.{strategy_id}`
- [x] All trades placed via realtime-strategies go through LLM consultation before execution
- [x] No direct writes to `signals.trading.*` from realtime-strategies remain
- [x] Consistent with microstructure strategy signal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)