### PR TITLE
[TECH-DEBT] Remove dead Prometheus NATS/strategy counters on /metrics

### DIFF
--- a/strategies/health/server.py
+++ b/strategies/health/server.py
@@ -40,23 +40,6 @@ except ImportError:
     config_rate_limit_middleware = None
 
 # Prometheus metrics
-STRATEGY_SIGNALS_GENERATED = Counter(
-    "strategy_signals_generated_total",
-    "Total signals generated",
-    ["strategy", "signal_type"],
-)
-NATS_MESSAGES_CONSUMED = Counter(
-    "nats_messages_consumed_total", "Total NATS messages consumed"
-)
-NATS_MESSAGES_PUBLISHED = Counter(
-    "nats_messages_published_total", "Total orders published to NATS"
-)
-STRATEGY_PROCESSING_TIME = Histogram(
-    "strategy_processing_time_seconds", "Time to process a message", ["strategy"]
-)
-STRATEGY_ERRORS = Counter(
-    "strategy_errors_total", "Total strategy errors", ["strategy", "error_type"]
-)
 CIRCUIT_BREAKER_STATE = Gauge(
     "circuit_breaker_state", "Circuit breaker state (0=closed, 1=open)", ["component"]
 )


### PR DESCRIPTION
## Summary
- Removes 5 dead Prometheus counters/histograms that were defined in `strategies/health/server.py` but never incremented or observed anywhere in the codebase
- `STRATEGY_SIGNALS_GENERATED` - defined but never called with `.inc()`
- `NATS_MESSAGES_CONSUMED` - defined but never called with `.inc()`
- `NATS_MESSAGES_PUBLISHED` - defined but never called with `.inc()`
- `STRATEGY_PROCESSING_TIME` - defined but never called with `.observe()` or `.time()`
- `STRATEGY_ERRORS` - defined but never called with `.inc()`

## Acceptance Criteria
- [x] Identify all Prometheus counters/histograms that are defined but never used
- [x] Remove or wire the dead metrics (decision: remove since wiring requires significant changes)
- [x] Ensure no tests reference the removed metrics
- [x] Pipeline passes (607 tests passed, 88.01% coverage)

## Testing Evidence
- All 607 tests pass
- Coverage: 88.01% (well above 78% threshold)
- Format and lint checks pass
- No test references to removed metrics

## Related Issues
Closes #161