### PR TITLE
[TECH-DEBT] #404 - Add startup log for effective NATS publish/consumer subjects

### DIFF
--- a/strategies/main.py
+++ b/strategies/main.py
@@ -68,6 +68,15 @@ class StrategiesService:
             environment=constants.ENVIRONMENT,
         )
 
+        self.logger.info(
+            "NATS subjects: effective publisher=%s, consumer=%s",
+            constants.NATS_TOPIC_INTENTS,
+            constants.NATS_CONSUMER_TOPIC,
+            event_type="nats_subject_config",
+            effective_publish_subject=constants.NATS_TOPIC_INTENTS,
+            consumer_subject=constants.NATS_CONSUMER_TOPIC,
+        )
+
         try:
             # Initialize MongoDB and Configuration Manager FIRST
             from strategies.db.mongodb_client import MongoDBClient

--- a/strategies/main.py
+++ b/strategies/main.py
@@ -69,9 +69,7 @@ class StrategiesService:
         )
 
         self.logger.info(
-            "NATS subjects: effective publisher=%s, consumer=%s",
-            constants.NATS_TOPIC_INTENTS,
-            constants.NATS_CONSUMER_TOPIC,
+            "NATS subjects configured",
             event_type="nats_subject_config",
             effective_publish_subject=constants.NATS_TOPIC_INTENTS,
             consumer_subject=constants.NATS_CONSUMER_TOPIC,


### PR DESCRIPTION
## Summary
Adds startup logging for effective NATS publish and consumer subjects as required by ticket #404 AC #3.

## Changes
### `strategies/main.py`
- Added startup log line showing effective publish subject (`NATS_TOPIC_INTENTS`) and consumer subject at service startup
- Structured log includes `event_type=nats_subject_config` for easy log filtering

## Why
Operators can now verify the active NATS routing configuration from startup logs without cross-referencing ConfigMaps.

## Validation
- ✅ `ruff check` passes
- ✅ 607 tests pass, 5 skipped, 3 xfailed
- ✅ No secrets in log lines

Closes #404 (in combination with PetroSa2/petrosa_k8s#433)