### PR TITLE
feat(#580): add intent_id generation and OTel tracing to realtime-strategies publisher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ pydantic>=2.0.0,<3.0.0
 structlog>=23.0.0
 
 # OpenTelemetry (unified via petrosa-otel package)
-# For local development: pip install -e ../petrosa_k8s/petrosa-otel[all]>=1.0.4
-petrosa-otel[all]>=1.0.4
+# For local development: pip install -e ../petrosa_k8s/petrosa-otel[all]>=1.0.6
+petrosa-otel[all]>=1.0.6
 # CLI and utilities
 typer>=0.9.0
 orjson>=3.9.0

--- a/strategies/core/publisher.py
+++ b/strategies/core/publisher.py
@@ -319,6 +319,24 @@ class TradeOrderPublisher:
             order_dict_with_trace = inject_trace_context(order_dict)
             order_message = json.dumps(order_dict_with_trace)
 
+            # Set decision.* OTel span attributes for this intent
+            try:
+                from opentelemetry import trace as _trace
+                from petrosa_otel import set_decision_context
+
+                set_decision_context(
+                    _trace.get_current_span(),
+                    intent_id=order.intent_id,
+                    strategy_id=order.strategy_name,
+                    symbol=order.symbol,
+                    action=order.side.value.lower(),
+                    confidence=order.confidence_score,
+                )
+            except ImportError:
+                pass
+            except Exception as _exc:
+                self.logger.debug("set_decision_context failed: %s", _exc)
+
             # Publish message to NATS (strategy-scoped subject for tradeengine wildcard)
             await self.nats_client.publish(
                 subject=self._signal_subject_for_order(order),

--- a/strategies/models/orders.py
+++ b/strategies/models/orders.py
@@ -5,6 +5,7 @@ This module contains Pydantic models for representing trade orders,
 order types, sides, and position management.
 """
 
+import uuid
 from datetime import datetime
 
 try:
@@ -83,6 +84,10 @@ class TradeOrder(BaseModel):
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict, description="Additional metadata"
+    )
+    intent_id: str = Field(
+        default_factory=lambda: uuid.uuid4().hex,
+        description="uuid4 hex string uniquely identifying this intent; generated at publish time",
     )
 
     @validator("symbol")
@@ -193,6 +198,7 @@ class TradeOrder(BaseModel):
             "confidence_score": self.confidence_score,
             "timestamp": self.timestamp.isoformat(),
             "metadata": self.metadata,
+            "intent_id": self.intent_id,
         }
 
         if self.price is not None:


### PR DESCRIPTION
## Summary
- Adds `intent_id` (uuid4 hex) field to `TradeOrder` model; included in `to_dict()` output
- `publisher.publish_order_sync()` calls `set_decision_context()` to propagate `decision.*` OTel span attributes per order
- Requires `petrosa-otel>=1.0.6` (see petrosa_k8s#581)

Closes petrosa_k8s#580

## Test plan
- [ ] 607 realtime-strategies tests pass
- [ ] Verify `TradeOrder.intent_id` is auto-generated as 32-char hex string
- [ ] Verify `to_dict()` includes `intent_id`
- [ ] Verify OTel span attributes set in publish_order_sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)