### PR TITLE
feat: add recommended_leverage to Signal contract (#177, P1.5-AC1)

### DIFF
--- a/strategies/models/signals.py
+++ b/strategies/models/signals.py
@@ -117,6 +117,21 @@ class Signal(BaseModel):
     take_profit_pct: float | None = Field(None, ge=0, le=1)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
+    # FR52 / P1.5-AC1 (#177) — content-addressable max-leverage opinion
+    # carried from the producer to CIO. `None` (not 0) means "no
+    # recommendation — CIO picks from strategy/portfolio defaults".
+    # The integer is the leverage multiplier the strategy backtest's
+    # max-leverage envelope supports (e.g. 1, 2, 5, 10). CIO arbitration
+    # logic against portfolio aggregates ships in a separate child story.
+    recommended_leverage: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Max leverage multiplier the producer's characterization supports. "
+            "None = no recommendation."
+        ),
+    )
+
     # Legacy compatibility fields
     signal_id: str | None = Field(None, description="Compatibility with contracts")
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -831,3 +831,55 @@ class TestSignalMetrics:
         assert isinstance(distribution, dict)
         # Should have distribution data when signals exist
         assert len(distribution) > 0 or metrics.total_signals_generated == 2
+
+
+# ---------------------------------------------------------------------------
+# FR52 / P1.5-AC1 (#177) — recommended_leverage on the signal contract.
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedLeverageField:
+    """recommended_leverage is optional, defaults None, accepts >=1 ints."""
+
+    def test_signal_defaults_recommended_leverage_to_none(self):
+        """Producers that don't set the field keep working (AC1.c)."""
+        signal = Signal(symbol="BTCUSDT", current_price=50000.0, price=50000.0)
+        assert signal.recommended_leverage is None
+
+    def test_signal_accepts_recommended_leverage(self):
+        signal = Signal(
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            price=50000.0,
+            recommended_leverage=5,
+        )
+        assert signal.recommended_leverage == 5
+
+    def test_signal_round_trips_recommended_leverage_through_dump_load(self):
+        original = Signal(
+            symbol="ETHUSDT",
+            current_price=3000.0,
+            price=3000.0,
+            recommended_leverage=3,
+        )
+        rebuilt = Signal(**original.model_dump())
+        assert rebuilt.recommended_leverage == 3
+
+    def test_signal_rejects_recommended_leverage_below_one(self):
+        """The field is ge=1 — 0 is not a valid 'no recommendation' sentinel
+        (use None for that)."""
+        with pytest.raises(ValidationError) as exc_info:
+            Signal(
+                symbol="BTCUSDT",
+                current_price=50000.0,
+                price=50000.0,
+                recommended_leverage=0,
+            )
+        assert "recommended_leverage" in str(exc_info.value)
+
+    def test_signal_dumps_none_when_field_omitted(self):
+        """A signal with no leverage opinion serializes the field as None —
+        CIO treats None as 'pick from defaults' (legacy behaviour preserved)."""
+        signal = Signal(symbol="BTCUSDT", current_price=50000.0, price=50000.0)
+        dumped = signal.model_dump()
+        assert dumped["recommended_leverage"] is None


### PR DESCRIPTION
Closes #177. Producer-side half of P1.5 leverage arbitration (parent petrosa_k8s#691). Adds optional `recommended_leverage: int | None` to `Signal`; None = no recommendation, ge=1 rejects 0 as sentinel.

## Test plan
- [x] 5 new tests pass (default-None, non-None, dump/load, rejects 0, dumps None when unset).
- [x] Full suite: **623 passed**, 5 skipped, 3 xfailed.
- [x] ruff check + ruff format clean.

Sibling: bot-ta-analysis#251 (same AC1, parallel producer). CIO arbitration ships in cio#137.

Closes #177